### PR TITLE
여행 초대 수락 거절 관리

### DIFF
--- a/Boleto/Boleto.xcodeproj/project.pbxproj
+++ b/Boleto/Boleto.xcodeproj/project.pbxproj
@@ -131,7 +131,6 @@
 		C798550C2CAEE07900C7FBCD /* GetSearchFriendRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C798550B2CAEE07900C7FBCD /* GetSearchFriendRequest.swift */; };
 		C7BC03ED2CA1A715004A0435 /* Array+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BC03EC2CA1A715004A0435 /* Array+.swift */; };
 		C7BC03EF2CA1D6C2004A0435 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BC03EE2CA1D6C2004A0435 /* String+.swift */; };
-		C7BC03F12CA1F042004A0435 /* DeleteTravelRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BC03F02CA1F042004A0435 /* DeleteTravelRequest.swift */; };
 		C7BC03F32CA2DF5A004A0435 /* MemoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BC03F22CA2DF5A004A0435 /* MemoryResponse.swift */; };
 		C7BC03F92CA52F84004A0435 /* ImageUploadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BC03F82CA52F84004A0435 /* ImageUploadRequest.swift */; };
 		C7BC03FB2CA5304E004A0435 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BC03FA2CA5304E004A0435 /* Encodable+.swift */; };
@@ -337,7 +336,6 @@
 		C798550B2CAEE07900C7FBCD /* GetSearchFriendRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSearchFriendRequest.swift; sourceTree = "<group>"; };
 		C7BC03EC2CA1A715004A0435 /* Array+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+.swift"; sourceTree = "<group>"; };
 		C7BC03EE2CA1D6C2004A0435 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
-		C7BC03F02CA1F042004A0435 /* DeleteTravelRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteTravelRequest.swift; sourceTree = "<group>"; };
 		C7BC03F22CA2DF5A004A0435 /* MemoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryResponse.swift; sourceTree = "<group>"; };
 		C7BC03F82CA52F84004A0435 /* ImageUploadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadRequest.swift; sourceTree = "<group>"; };
 		C7BC03FA2CA5304E004A0435 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
@@ -746,7 +744,6 @@
 				C7DA9C572C9FDA1E00BE752D /* TravelRequest.swift */,
 				C75F26052CAF525D00350B73 /* TravelFetchRequest.swift */,
 				C7BC03F82CA52F84004A0435 /* ImageUploadRequest.swift */,
-				C7BC03F02CA1F042004A0435 /* DeleteTravelRequest.swift */,
 				C7DA24332C9EA38C00DA8ADF /* LoginUserRequest.swift */,
 				C76DE6AB2CA7FACD0027014F /* AuthUserIdRequest.swift */,
 				C772E37D2CAB46EF009EEA26 /* StickerRequest.swift */,
@@ -1316,7 +1313,6 @@
 				C7F8024A2CE5DF020048B4EE /* FriendClient.swift in Sources */,
 				C7F802542CE862C30048B4EE /* ReceiveFriendView.swift in Sources */,
 				C7D5B40E2C6DCFCC00BBF7BE /* AddFourCutView.swift in Sources */,
-				C7BC03F12CA1F042004A0435 /* DeleteTravelRequest.swift in Sources */,
 				C7D5B41F2C707B1A00BBF7BE /* AddFourCutFeature.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Boleto/Boleto/App/AppFeature.swift
+++ b/Boleto/Boleto/App/AppFeature.swift
@@ -69,6 +69,7 @@ struct AppFeature {
         case tabNotification
         case sendToFrameView(SpotType)
         case sendToBadgeView(StickerCodes)
+        case sendToInvitedView(Int)
         case tabmyPage
         case path(StackActionOf<Destination>)
         case popAll
@@ -199,6 +200,9 @@ struct AppFeature {
                 return .none
             case .sendToFrameView(let spot):
                 state.path.append(.frameNotificationView(FrameNotificationFeature.State( badgeType: spot)))
+                return .none
+            case .sendToInvitedView(let travelId):
+                state.path.append(.invitedTravel(MyInvitedFeature.State(invitedTravelID: travelId)))
                 return .none
             case .allTicket(.touchAddTravel):
                 state.path.append(.addticket(AddTicketFeature.State()))

--- a/Boleto/Boleto/App/BoletoApp.swift
+++ b/Boleto/Boleto/App/BoletoApp.swift
@@ -72,21 +72,24 @@ struct BoletoApp: App {
         }
     }
     func handlePushNotification(data: [String: Any]) async {
-        guard let type = data["NotificationType"] as? String else { return }
+        guard let type = data["eventType"] as? String else { return }
         
         switch type {
         case "badge":
             if let stickerTypeString = data["StickerImage"] as? String,
                let stickerType = StickerCodes(rawValue: stickerTypeString) {
                        delegate.store.send(.sendToBadgeView(stickerType))
-                //
                    }
         case "fourCutframe":
             if let spotString = data["Spot"] as? String,
                let spotType = SpotType.fromUpperString(spotString) {
                 delegate.store.send(.sendToFrameView(spotType))}
 
-            break
+        case "TRAVEL_INVITE":
+            if let travelId = data["travelId"]  as? String{
+                delegate.store.send(.sendToInvitedView(Int(travelId)!))
+            }
+            
         default:
             break
         }

--- a/Boleto/Boleto/App/ContentView.swift
+++ b/Boleto/Boleto/App/ContentView.swift
@@ -63,7 +63,7 @@ struct ContentView: View {
                     MyFrameView()
                 case let .mySticker(store):
                     MyStickerView(store: store)
-        
+                        .navigationBarTitleDisplayMode(.inline)
                 case let .friendLists(store):
                     FriendListView(store: store)
                 case let .invitedTravel(store):

--- a/Boleto/Boleto/Client/TravelClient.swift
+++ b/Boleto/Boleto/Client/TravelClient.swift
@@ -16,6 +16,8 @@ struct TravelClient{
     var deleteTravel: @Sendable (Int) async throws -> Bool
     var putEditmodeTravel: @Sendable (String, Int) async throws -> Void
     var patchTravel: @Sendable (TravelFetchRequest, Int) async throws -> Bool
+    var acceptTravel: @Sendable (Int) async throws -> Void
+    var rejectTravel: @Sendable (Int) async throws -> Void
 }
 extension TravelClient : DependencyKey {
     static var liveValue: Self = {
@@ -46,6 +48,11 @@ extension TravelClient : DependencyKey {
                     endpoint: TravelRouter.updateTravel(request, travelId: travelId),
                     responseType: GeneralResponse<TravelResponse>.self
                 ).success
+            }, acceptTravel: {travelId in
+                try await NetworkManager.request(endpoint: TravelRouter.patchAccept(travelId: travelId), responseType: GeneralResponse<EmptyData>.self)
+            }, rejectTravel: {travelId in
+                try await NetworkManager.request(endpoint: TravelRouter.patchreject(travelId: travelId), responseType: GeneralResponse<EmptyData>.self)
+                
             }
           
                 //patchTravel: { req in

--- a/Boleto/Boleto/Client/TravelClient.swift
+++ b/Boleto/Boleto/Client/TravelClient.swift
@@ -12,10 +12,10 @@ import ComposableArchitecture
 @DependencyClient
 struct TravelClient{
     var postTravel: @Sendable (TravelRequest) async throws -> Bool
-    var getAlltravel: @Sendable () async throws -> [Ticket]
+    var getAlltravel: @Sendable (Bool) async throws -> [Ticket]
     var deleteTravel: @Sendable (Int) async throws -> Bool
     var putEditmodeTravel: @Sendable (String, Int) async throws -> Void
-    var patchTravel: @Sendable (TravelFetchRequest) async throws -> Bool
+    var patchTravel: @Sendable (TravelFetchRequest, Int) async throws -> Bool
 }
 extension TravelClient : DependencyKey {
     static var liveValue: Self = {
@@ -23,14 +23,14 @@ extension TravelClient : DependencyKey {
             postTravel: { request in
                 try await NetworkManager.request(endpoint: TravelRouter.postTravel(request), responseType: GeneralResponse<String>.self).success
             },
-            getAlltravel: {
-                let response = try await NetworkManager.request(endpoint: TravelRouter.getAllTravel, responseType: GeneralResponse<[TravelResponse]>.self)
+            getAlltravel: { isAccepted in
+                let response = try await NetworkManager.request(endpoint: TravelRouter.getAllTravel(isAccepted: isAccepted), responseType: GeneralResponse<[TravelResponse]>.self)
                 guard let data = response.data else {throw CustomError.invalidResponse}
                 return data.toTicket()
 
             }, deleteTravel: { travelID in
                 try await NetworkManager.request(
-                    endpoint: TravelRouter.deleteTravel(SingleTravelRequest(travelID: travelID)),
+                    endpoint: TravelRouter.deleteTravel(travelId: travelID),
                     responseType: GeneralResponse<EmptyData>.self
                 ).success
             }, putEditmodeTravel: { lock, travelid in
@@ -41,9 +41,9 @@ extension TravelClient : DependencyKey {
                 guard response.success else {
                     throw CustomError.alreadyLocked
                 }
-            }, patchTravel: { request in
+            }, patchTravel: { request, travelId in
                 try await NetworkManager.request(
-                    endpoint: TravelRouter.updateTravel(request),
+                    endpoint: TravelRouter.updateTravel(request, travelId: travelId),
                     responseType: GeneralResponse<TravelResponse>.self
                 ).success
             }

--- a/Boleto/Boleto/Models/NotificationModel.swift
+++ b/Boleto/Boleto/Models/NotificationModel.swift
@@ -16,7 +16,7 @@ protocol NotificationProtocol {
 struct BadgeNotification: NotificationProtocol {
 
     var infoDictionary: [AnyHashable: String] {
-        ["NotificationType": "badge", "StickerImage": stickerImageType.rawValue]
+        ["eventType": "badge", "StickerImage": stickerImageType.rawValue]
      }
     var id: String
     var stickerImageType: StickerCodes
@@ -39,7 +39,7 @@ struct FrameNotification: NotificationProtocol {
     }
     
     var infoDictionary: [AnyHashable: String] {
-         ["NotificationType": "fourCutframe", "Spot": id]
+         ["eventType": "fourCutframe", "Spot": id]
      }
     
 }

--- a/Boleto/Boleto/Models/Ticket.swift
+++ b/Boleto/Boleto/Models/Ticket.swift
@@ -37,7 +37,7 @@ extension Ticket {
             arrival: .seoul,    // Replace with appropriate SpotType
             startDate: Calendar.current.date(byAdding: .day, value: -2, to: Date())!,
             endDate: Calendar.current.date(byAdding: .day, value: -1, to: Date())!,
-            participant: [],     // Replace with appropriate [FriendDummy] if needed
+            participant: [MemberModel(id: 81, name: "유", nickname: "모해",imageUrl: nil)],     // Replace with appropriate [FriendDummy] if needed
             keywords: [.activity, .alone],
             color: .blue
         ),
@@ -47,7 +47,7 @@ extension Ticket {
             arrival: .seoul,    // Replace with appropriate SpotType
             startDate: Calendar.current.date(byAdding: .day, value: -1, to: Date())!,
             endDate: Calendar.current.date(byAdding: .day, value: 1, to: Date())!,
-            participant: [],     // Replace with appropriate [FriendDummy] if needed
+            participant: [MemberModel(id: 81, name: "유", nickname: "모해",imageUrl: nil)],
             keywords: [.fit, .alone],
             color: .purple
         ),
@@ -57,20 +57,20 @@ extension Ticket {
             arrival: .seoul,    // Replace with appropriate SpotType
             startDate: Calendar.current.date(byAdding: .day, value: 1, to: Date())!,
             endDate: Calendar.current.date(byAdding: .day, value: 2, to: Date())!,
-            participant: [],     // Replace with appropriate [FriendDummy] if needed
-            keywords: [.city, .fandom],
-            color: .yellow
-        ),
-        Ticket(
-            travelID: 10,
-            departaure: .dummy, // Replace with appropriate SpotType
-            arrival: .seoul,    // Replace with appropriate SpotType
-            startDate: Calendar.current.date(byAdding: .day, value:11, to: Date())!,
-            endDate: Calendar.current.date(byAdding: .day, value: 19, to: Date())!,
-            participant: [],     // Replace with appropriate [FriendDummy] if needed
+            participant: [MemberModel(id: 81, name: "유", nickname: "모해",imageUrl: nil)],
             keywords: [.city, .fandom],
             color: .yellow
         )
+//        Ticket(
+//            travelID: 10,
+//            departaure: .dummy, // Replace with appropriate SpotType
+//            arrival: .seoul,    // Replace with appropriate SpotType
+//            startDate: Calendar.current.date(byAdding: .day, value:11, to: Date())!,
+//            endDate: Calendar.current.date(byAdding: .day, value: 19, to: Date())!,
+//            participant: [MemberModel(id: 81, name: "유", nickname: "모해",imageUrl: nil)],  
+//            keywords: [.city, .fandom],
+//            color: .yellow
+//        )
     ]
 }
 

--- a/Boleto/Boleto/Network/DTO/Request/TravelFetchRequest.swift
+++ b/Boleto/Boleto/Network/DTO/Request/TravelFetchRequest.swift
@@ -14,7 +14,6 @@ struct TravelFetchRequest: Encodable {
     let endDate: String
     let members: [Int]
     let color: String
-    var travelId: Int
     enum CodingKeys: String, CodingKey {
         case startDate = "start_date"
         case endDate = "end_date"
@@ -23,6 +22,5 @@ struct TravelFetchRequest: Encodable {
         case color
         case members
         case keyword
-        case travelId = "travel_id"
     }
 }

--- a/Boleto/Boleto/Network/Router/TravelRouter.swift
+++ b/Boleto/Boleto/Network/Router/TravelRouter.swift
@@ -13,6 +13,8 @@ enum TravelRouter {
     case putTravelEdit(EditModeRequest, travelid: Int)
     case deleteTravel(travelId: Int)
     case getAllTravel(isAccepted: Bool)
+    case patchAccept(travelId: Int)
+    case patchreject(travelId: Int)
 }
 extension TravelRouter: NetworkProtocol {
     
@@ -31,6 +33,10 @@ extension TravelRouter: NetworkProtocol {
             ""
         case .putTravelEdit(_, let travelId):
             "/\(travelId)/status"
+        case .patchreject(let travelId):
+            "/\(travelId)/reject"
+        case .patchAccept(let travelId):
+            "/\(travelId)/accept"
         }
     }
     var method: HTTPMethod {
@@ -46,6 +52,8 @@ extension TravelRouter: NetworkProtocol {
                 .get
         case .putTravelEdit:
                 .put
+        case .patchreject, .patchAccept:
+                .patch
         }
     }
     var parameters: RequestParams {
@@ -60,6 +68,8 @@ extension TravelRouter: NetworkProtocol {
             return  .query(["isAccepted": isAccepted])
         case let .putTravelEdit(editRequest, travelid):
             return .body(editRequest)
+        default:
+            return .none
         }
     }
     var multipartData: MultipartFormData? {

--- a/Boleto/Boleto/Network/Router/TravelRouter.swift
+++ b/Boleto/Boleto/Network/Router/TravelRouter.swift
@@ -9,26 +9,26 @@ import Alamofire
 import Foundation
 enum TravelRouter {
     case postTravel(TravelRequest)
-    case updateTravel(TravelFetchRequest)
+    case updateTravel( TravelFetchRequest, travelId: Int)
     case putTravelEdit(EditModeRequest, travelid: Int)
-    case deleteTravel(SingleTravelRequest)
-    case getAllTravel
+    case deleteTravel(travelId: Int)
+    case getAllTravel(isAccepted: Bool)
 }
 extension TravelRouter: NetworkProtocol {
     
     var baseURL: String {
-        return CommonAPI.api+"/api/v1/travel"
+        return CommonAPI.api+"/api/v1/travels"
     }
     var path: String {
         switch self {
         case .postTravel:
-            "/create"
-        case .updateTravel:
-            "/update"
-        case .deleteTravel:
-            "/delete"
+            ""
+        case .updateTravel(_, let travelId):
+            "/\(travelId)"
+        case .deleteTravel(let travelId):
+            "/\(travelId)"
         case .getAllTravel:
-            "/get/all"
+            ""
         case .putTravelEdit(_, let travelId):
             "/\(travelId)/status"
         }
@@ -52,12 +52,12 @@ extension TravelRouter: NetworkProtocol {
         switch self {
         case .postTravel(let travelDTO):
             return .body(travelDTO)
-        case .updateTravel(let travelDTO):
+        case .updateTravel(let travelDTO, _):
             return .body(travelDTO)
         case .deleteTravel(let deleteDTO):
             return  .query(deleteDTO)
-        case .getAllTravel:
-            return  .none
+        case .getAllTravel(let isAccepted):
+            return  .query(["isAccepted": isAccepted])
         case let .putTravelEdit(editRequest, travelid):
             return .body(editRequest)
         }

--- a/Boleto/Boleto/Views/AddTravel/AddTicketFeature.swift
+++ b/Boleto/Boleto/Views/AddTravel/AddTicketFeature.swift
@@ -159,9 +159,9 @@ struct AddTicketFeature {
                                                           startDate: startDateString,
                                                           endDate: endDateString,
                                                           members: friendsId ?? [],
-                                                          color: mode == .add ? TicketColor.random().rawValue : ticketColor!.rawValue, travelId: travelId!)
+                                                          color: mode == .add ? TicketColor.random().rawValue : ticketColor!.rawValue)
                         do {
-                            let result = try await travelClient.patchTravel(request)
+                            let result = try await travelClient.patchTravel(request, travelId!)
                             if result {
                                 await send(.successTicket)
                             } else {

--- a/Boleto/Boleto/Views/AllTicketsOverView/AllTicketsOverViewFeature.swift
+++ b/Boleto/Boleto/Views/AllTicketsOverView/AllTicketsOverViewFeature.swift
@@ -59,7 +59,7 @@ struct AllTicketsOverViewFeature {
                 return .none
             case .fetchTickets:
                 return .run { send in
-                    let data = try await travelClient.getAlltravel()
+                    let data = try await travelClient.getAlltravel(true)
                     await send(.updateTickets(data))
                 }
             case .updateTickets(let tickets):

--- a/Boleto/Boleto/Views/MyPage/InvitedTickets/MyInvitedFeature.swift
+++ b/Boleto/Boleto/Views/MyPage/InvitedTickets/MyInvitedFeature.swift
@@ -8,56 +8,91 @@
 import ComposableArchitecture
 @Reducer
 struct MyInvitedFeature {
-    @Dependency(\.dismiss) var dismiss
+    
     @ObservableState
     struct State: Equatable {
         var  invitedTickets = [Ticket]()
+        var invitedTravelID: Int?
         @Presents var alert: AlertState<Action.Alert>?
     }
-    enum Action {
+    enum Action: Equatable {
         case alert(PresentationAction<Alert>)
-        case tapRefuseButton
-        case tapAcceptButton
+        case fetchAllInvitedTickets
+        case updateinvitedTickets([Ticket])
+        case tapRefuseButton(Int)
+        case tapAcceptButton(Int)
         case backbuttonTapped
+        case showAcceptButton
+        case initializeView
         @CasePathable
-        enum Alert {
-            case refuseButtonTapped
+        enum Alert: Equatable {
+            case refuseButtonTapped(Int)
             case acceptButtonTapped
         }
     }
-    
+    @Dependency(\.dismiss) var dismiss
+    @Dependency(\.travelClient) var travelClient
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
-            case .alert(.presented(.acceptButtonTapped)):
-                print("HI")
+            case .initializeView:
+                return .run { [invitedTravelID = state.invitedTravelID] send in
+                    await send(.fetchAllInvitedTickets)
+                    
+                    // 2. invitedTravelID 확인 후 showAcceptButton 실행
+                    if invitedTravelID != nil {
+                        await send(.showAcceptButton)
+                    }
+                }
+            case .fetchAllInvitedTickets:
+                return .run { send in
+                    let tickets = try await travelClient.getAlltravel(false)
+                    await send(.updateinvitedTickets(tickets))
+                }
+            case .updateinvitedTickets(let tickets):
+                state.invitedTickets = tickets
                 return .none
+            case .alert(.presented(.acceptButtonTapped)):
+                guard let travelId = state.invitedTravelID else { return .none }
+                return .run { send in
+                    try await travelClient.acceptTravel(travelId)
+                    await send(.fetchAllInvitedTickets)
+                }
+                
+            case .alert(.presented(.refuseButtonTapped(let travelId))):
+                return .run { send in
+                    try await travelClient.rejectTravel(travelId)
+                    await send(.fetchAllInvitedTickets)
+                }
             case .alert:
                 return .none
-            case .tapRefuseButton:
+            case .tapRefuseButton(let travelId):
                 state.alert = AlertState {
                     TextState("초대를 거절하시겠어요?")
                 } actions: {
                     ButtonState(role: .cancel) {
-                          TextState("취소")
-                        }
-                    ButtonState(action: .acceptButtonTapped) {
-                          TextState("거절")
-                        }
+                        TextState("취소")
+                    }
+                    ButtonState(action: .refuseButtonTapped(travelId)) {
+                        TextState("거절")
+                    }
                 }message: {
                     TextState("거절한 티켓은 삭제되어 다시 볼 수 없어요.")
                 }
                 return .none
-            case .tapAcceptButton:
+            case .tapAcceptButton(let travelId):
+                state.invitedTravelID = travelId
+                return .send(.showAcceptButton)
+            case .showAcceptButton:
                 state.alert = AlertState {
                     TextState("초대를 수락하시겠어요?")
                 } actions: {
                     ButtonState(role: .cancel) {
-                          TextState("취소")
-                        }
+                        TextState("취소")
+                    }
                     ButtonState(action: .acceptButtonTapped) {
-                          TextState("수락")
-                        }
+                        TextState("수락")
+                    }
                 }message: {
                     TextState("수락한 티켓은 나의 여행에 자동으로 추가돼요.")
                 }

--- a/Boleto/Boleto/Views/MyPage/InvitedTickets/MyInvitedView.swift
+++ b/Boleto/Boleto/Views/MyPage/InvitedTickets/MyInvitedView.swift
@@ -10,19 +10,29 @@ import ComposableArchitecture
 struct MyInvitedView: View {
     @Bindable var store: StoreOf<MyInvitedFeature>
     var body: some View {
-        VStack(spacing: 35) {
-            ForEach(store.invitedTickets, id: \.startDate) { ticket in
-                SwipalbleTicketCell(ticket: ticket, onAccept: {
-                    store.send(.tapAcceptButton)
-                }, onDelete: {
-                    store.send(.tapRefuseButton)
-                }, invitedMode: true)
-
-            }
-        }.padding(.horizontal,32)
-        
+        ScrollView {
+            LazyVStack(spacing: 32) {
+                ForEach(store.invitedTickets, id: \.startDate) { ticket in
+                    VStack(spacing: 10){
+                        HStack {
+                            Text("From. \(ticket.participant[0].nickname)")
+                                .customTextStyle(.subheadline)
+                                .foregroundStyle(.white)
+                            Spacer()
+                        }
+                        SwipalbleTicketCell(ticket: ticket, onAccept: {
+                            store.send(.tapAcceptButton(ticket.travelID))
+                        }, onDelete: {
+                            store.send(.tapRefuseButton(ticket.travelID))
+                        }, invitedMode: true)
+                    }
+                }
+                Spacer()
+            }.padding(.top, 40)
+        }
+        .scrollIndicators(.hidden)
+            .padding(.horizontal,32)
             .applyBackground(color: .background)
-        
             .alert($store.scope(state: \.alert, action: \.alert))
             .navigationBarBackButtonHidden()
             .toolbar {
@@ -37,12 +47,15 @@ struct MyInvitedView: View {
                     })
                 }
             }
+//            .onAppear {
+//                store.send(.initializeView)
+//            }
     }
    
 }
 
 #Preview {
-    MyInvitedView(store: .init(initialState: MyInvitedFeature.State(), reducer: {
+    MyInvitedView(store: .init(initialState: MyInvitedFeature.State(invitedTickets: Ticket.mockTickets), reducer: {
         MyInvitedFeature()
     }))
 }

--- a/Boleto/Boleto/Views/MyPage/InvitedTickets/SwipalbleTicketCell.swift
+++ b/Boleto/Boleto/Views/MyPage/InvitedTickets/SwipalbleTicketCell.swift
@@ -55,12 +55,13 @@ struct SwipalbleTicketCell: View {
                         if invitedMode {
                             Image(systemName: "checkmark")
                                 .resizable()
-                                .frame(width: 29,height: 29)
+                                .scaledToFit()
+                                .frame(width: 23,height: 16)
                                 .foregroundStyle(Color.white)
+                                .padding(.all, 14)
                                 .background(
                                     Circle()
-                                        .frame(width: 42,height: 42)
-                                        .foregroundStyle(Color.gray1)
+                                        .fill(Color.gray1)
                                 )
                         } else {
                             Image(systemName: "chevron.forward")
@@ -71,7 +72,7 @@ struct SwipalbleTicketCell: View {
                                         .foregroundStyle(Color.gray1)
                                 )
                         }
-       
+                        
                         
                     })
                     .padding(.trailing, 20)
@@ -93,17 +94,19 @@ struct SwipalbleTicketCell: View {
                             }else { offset = 0}
                         }
                     }
-
-
+                    
+                    
                 )
         }
         .frame(height: 141)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
     }
 }
 
-//#Preview {
-//    SwipalbleTicketCell(ticket: Ticket(departaure: "Seoul", arrival: "Busan", startDate: "2024.1.28", endDate: "2024.04.12", participant: [Person(image: "beef3", name: "강병호"),Person(image: "beef1", name: "김수민"),Person(image: "beef2", name: "하잇"),Person(image: "beef4", name: "면답")], keywords: [.activity])) {
-//        print("HI")
-//    }
-//}
+#Preview {
+    SwipalbleTicketCell(ticket: Ticket.mockTickets[0], onAccept: {
+        
+    }, onDelete: {
+        
+    }, invitedMode: true)
+}

--- a/Boleto/Boleto/Views/MyPage/MyFrame/MyFrameView.swift
+++ b/Boleto/Boleto/Views/MyPage/MyFrame/MyFrameView.swift
@@ -27,12 +27,15 @@ struct MyFrameView: View {
                 }
                 Spacer()
             }
-            .padding(.vertical, 16)
+            .padding(.top, 40)
+            .padding(.bottom, 16)
             Spacer()
             frameGridView
-                
+            Spacer()
+            
         }
         .padding(.horizontal,32).applyBackground(color: .background)
+        .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .principal) {
@@ -51,43 +54,40 @@ struct MyFrameView: View {
     }
     @MainActor
     private var frameGridView: some View {
-        ZStack(alignment:.top) {
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color.gray1)
-            ScrollView {
-                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 24, content: {
-                    ForEach(frames) { frame in
-                        ZStack {
-                            KFImage.url(URL(string: frame.frameURL))
-                                .resizable()
-                                .frame(width: 134,height: 150)
-                                .clipShape(RoundedRectangle(cornerRadius: 5))
-                            VStack(spacing: 6) {
-                                HStack(spacing: 6) {
-                                    RoundedRectangle(cornerRadius: 3)
-                                        .fill(.gray1)
-                                        .frame(width: 55,height: 55)
-                                    RoundedRectangle(cornerRadius: 3)
-                                        .fill(.gray1)
-                                        .frame(width: 55,height: 55)
-                                }
-                                HStack(spacing: 6) {
-                                    RoundedRectangle(cornerRadius: 3)
-                                        .fill(.gray1)
-                                        .frame(width: 55,height: 55)
-                                    RoundedRectangle(cornerRadius: 3)
-                                        .fill(.gray1)
-                                        .frame(width: 55,height: 55)
-                                }
-                            }.padding(.horizontal, 8)
-                                .padding(.bottom,24)
-                        }
+        ScrollView {
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 24, content: {
+                ForEach(frames) { frame in
+                    ZStack {
+                        KFImage.url(URL(string: frame.frameURL))
+                            .resizable()
+                            .frame(width: 134,height: 150)
+                            .clipShape(RoundedRectangle(cornerRadius: 5))
+                        VStack(spacing: 6) {
+                            HStack(spacing: 6) {
+                                RoundedRectangle(cornerRadius: 3)
+                                    .fill(.gray1)
+                                    .frame(width: 55,height: 55)
+                                RoundedRectangle(cornerRadius: 3)
+                                    .fill(.gray1)
+                                    .frame(width: 55,height: 55)
+                            }
+                            HStack(spacing: 6) {
+                                RoundedRectangle(cornerRadius: 3)
+                                    .fill(.gray1)
+                                    .frame(width: 55,height: 55)
+                                RoundedRectangle(cornerRadius: 3)
+                                    .fill(.gray1)
+                                    .frame(width: 55,height: 55)
+                            }
+                        }.padding(.horizontal, 8)
+                            .padding(.bottom,24)
                     }
                 }
-                ).padding(.horizontal, 18)
-                    .padding(.vertical, 24)
+                Spacer()
             }
-        }.frame(maxHeight: .infinity)
+            ).padding(.horizontal, 18)
+                .padding(.vertical, 24)
+        }
     }
     
 }

--- a/Boleto/Boleto/Views/MyPage/MySticker/MyStickerView.swift
+++ b/Boleto/Boleto/Views/MyPage/MySticker/MyStickerView.swift
@@ -17,6 +17,7 @@ struct MyStickerView: View {
                 Group {
                     Text("\(store.myStickers.count)").foregroundStyle(.main)+Text("/\(store.allStickersCount)개").foregroundStyle(.gray6)
                 }   .customTextStyle(.title)
+                    .padding(.top, 40)
                     .padding(.bottom,12)
                 Text("여행을 통해 명소 스티커를 모아보세요.")
                     .foregroundStyle(.gray5)


### PR DESCRIPTION
[![BO-56](https://badgen.net/badge/JIRA/BO-56/65B1F7?icon=jira)](https://jira.company.com/browse/BO-56) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Boletto&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- 제목 : #64  여행 초대 관리 

## 🧞‍♂️ 작업 내용

- API RestFul하게 수정.
- 친구가 여행을 초대한 경우 상대방에게는 noti가 도착하고 해당 노티를 클릭하면 초대받는 뷰로 이동 후 alert.
- 여행 요청 거절 완료



  <br/>

## ➕ 이슈 링크

-  #64

[BO-56]: https://boletoteam.atlassian.net/browse/BO-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ